### PR TITLE
Added copy rules for qgenericbearer and qsqlodbc plugin files

### DIFF
--- a/ExtLib/Qt5Support.cmake
+++ b/ExtLib/Qt5Support.cmake
@@ -560,6 +560,24 @@ macro(CMP_AddQt5Support Qt5Components NeedQtWebEngine ProjectBinaryDir VarPrefix
     endif()
   endif()
 
+  list(FIND Qt5_COMPONENTS "Network" NeedsNetwork)
+  if(NeedsNetwork GREATER -1)
+    AddQt5Plugins(PLUGIN_NAMES QGenericEnginePlugin
+                  PLUGIN_FILE "${QT_PLUGINS_FILE}"
+                  PLUGIN_FILE_TEMPLATE "${QT_PLUGINS_FILE_TEMPLATE}"
+                  # PLUGIN_SUFFIX Plugin
+                  PLUGIN_TYPE bearer)
+  endif()
+
+  list(FIND Qt5_COMPONENTS "Sql" NeedsSql)
+  if(NeedsSql GREATER -1)
+    AddQt5Plugins(PLUGIN_NAMES QODBCDriverPlugin
+                  PLUGIN_FILE "${QT_PLUGINS_FILE}"
+                  PLUGIN_FILE_TEMPLATE "${QT_PLUGINS_FILE_TEMPLATE}"
+                  # PLUGIN_SUFFIX Plugin
+                  PLUGIN_TYPE sqldrivers)
+  endif()
+
   #-----------------------------------------------------------------------------------
   # Copy over the proper QWebEngine Components
   if("${NeedQtWebEngine}" STREQUAL "ON" OR "${NeedQtWebEngine}" STREQUAL "TRUE")


### PR DESCRIPTION
* QGenericBearer handles network access particularly in how it handles network management.  This can be detecting network access and accessing the computer's IP address.
* QSqlOdbc is used to access ODBC drivers for SQL database connections.  This provides preset definitions for the server connection string, database name, username, and password without requesting this information from the user every time.