### PR TITLE
IGeometryGrid API Update, Python Fixes, MXA Removal

### DIFF
--- a/CoreTests/cmpGenerateVersionString.cpp
+++ b/CoreTests/cmpGenerateVersionString.cpp
@@ -139,14 +139,15 @@ inline std::string tifDateTime() {
   return ss.str();
 }
 
-namespace MXA {
+namespace SIMPL_Gen
+{
 
 /**
  * @brief Generates a String suitable for using as a version string for
  * applications.
  * @return
  */
-inline std::string MXAVersionString()
+inline std::string SIMPL_GenVersionString()
 {
   TimeType long_time = 0;
   TimeFunc(&long_time);
@@ -193,12 +194,10 @@ inline unsigned long long int getMilliSeconds()
 #endif
 }
 
-
-} // end Namespace MXA
-
+} // end Namespace SIMPL_Gen
 
 int main(int argc, char **argv) {
-  std::cout << MXA::MXAVersionString();
+  std::cout << SIMPL_Gen::SIMPL_GenVersionString();
   return 0;
 }
 

--- a/Modules/FindSZip.cmake
+++ b/Modules/FindSZip.cmake
@@ -5,7 +5,7 @@
 #  SZLIB_LIBRARIES   - List of libraries when using szlib.
 #  SZLIB_FOUND       - True if szlib found.
 
-MESSAGE(STATUS "MXAFindSZip.cmake: This File is Unfinished. Use at your own risk")
+MESSAGE(STATUS "FindSZip.cmake: This File is Unfinished. Use at your own risk")
 IF (SZLIB_INCLUDE_DIR)
   # Already in cache, be silent
   SET(SZLIB_FIND_QUIETLY TRUE)


### PR DESCRIPTION
The API is changed to use a FloatVec3Type or SizeVec3Type (both alias for SIMPLArray<T, N>) so that
the API is consistent among the various classes and easy to use within SIMPL/DREAM.3D and its plugins.
The use of the std::tuple<T> based return types is deprecated and removed.

The Python script files were completely reorganized to put the scripts with their plugins. Most of
the scripts were tested on a macOS machine and added to the ctest suite of unit tests. For each script
a bash script is created that drives the test. The Python tests are dependant on an Anaconda3 installation
being used. A few of the Python tests are still failing but those will be fixed eventually

The source code was searched for the old and deprecated MXA strings and classes and the old code was
either removed or renamed to SIMPL.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>