### PR TITLE
Topic/osd gui packaging changes

### DIFF
--- a/ExtLib/VtkSupport.cmake
+++ b/ExtLib/VtkSupport.cmake
@@ -169,6 +169,13 @@ function(CMP_FindVtkComponents)
     AddVtkCopyInstallRules(LIBS ${Z_COMPONENTS})
   endif()
 
+  #------------------------------------------------------------------------------
+  # Make sure we have Vtk installed and available
+  if(VTK_FOUND)
+      get_property(SIMPLibSearchDirs GLOBAL PROPERTY SIMPLibSearchDirs)
+      file(APPEND "${SIMPLibSearchDirs}" "${VTK_RUNTIME_DIRS};")
+  endif()
+
 endfunction()
 
 # # --------------------------------------------------------------------

--- a/OSX_Tools/CompleteBundle.cmake.in
+++ b/OSX_Tools/CompleteBundle.cmake.in
@@ -66,10 +66,10 @@ function(gp_item_default_embedded_path_override item default_embedded_path_var)
     set(path "@executable_path/../Plugins/imageformats")
     set(overridden 1)
   # Lastly pick up any Plugins that simply have the ".dylib" extension
-  elseif(item MATCHES "\\.dylib$")
-    message(STATUS "%% Support Library: ${item}")
-    set(path "@executable_path/../lib")
-    set(overridden 1)
+  #elseif(item MATCHES "\\.dylib$")
+    #message(STATUS "%% Support Library: ${item}")
+    #set(path "@executable_path/../lib")
+    #set(overridden 1)
   endif()
 
   # Embed frameworks in the embedded "Frameworks" directory (sibling of MacOS):


### PR DESCRIPTION
* Adding VTK library directory to the list of directories that the packager searches through to look for library files.
* Turning off the @executable_path override for library files.