### PR TITLE
Fixing issues with Qt5.14 on Windows and Plugins directory.

### DIFF
--- a/ExtLib/Qt5Support.cmake
+++ b/ExtLib/Qt5Support.cmake
@@ -395,7 +395,9 @@ macro(CMP_AddQt5Support Qt5Components ProjectBinaryDir VarPrefix)
     get_property(QT_PLUGINS_FILE_TEMPLATE GLOBAL PROPERTY QtPluginsCMakeFile)
   endif()
 
-  AddQtConfTargets(QT_PLUGINS_DIR ${QM_QT_INSTALL_PLUGINS})
+  if(NOT DREAM3D_ANACONDA)
+    AddQtConfTargets(QT_PLUGINS_DIR ${QM_QT_INSTALL_PLUGINS})
+  endif()
 
   file(WRITE ${QT_PLUGINS_FILE_TEMPLATE} "")
   file(WRITE ${QT_PLUGINS_FILE} "")
@@ -498,5 +500,4 @@ macro(CMP_AddQt5Support Qt5Components ProjectBinaryDir VarPrefix)
   list(APPEND CMP_LIB_SEARCH_DIRS ${QT_BINARY_DIR} ${QT_LIBRARY_DIR} )
 
 endmacro()
-
 


### PR DESCRIPTION
Qt 5.14 allows relocatable Qt installations and so now we either need
to copy in all of the plugins from the Qt installation or just write
out a qt.conf file that points to the proper location for the Qt Plugins
directory. We chose the second option.

Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>